### PR TITLE
Add unit label functionality

### DIFF
--- a/common/lib_tree_model.cpp
+++ b/common/lib_tree_model.cpp
@@ -129,7 +129,6 @@ LIB_TREE_NODE_UNIT::LIB_TREE_NODE_UNIT( LIB_TREE_NODE* aParent, LIB_TREE_ITEM* a
 {
     static void* locale = nullptr;
     static wxString namePrefix;
-
     // Fetching translations can take a surprising amount of time when loading libraries,
     // so only do it when necessary.
     if( Pgm().GetLocale() != locale )
@@ -145,7 +144,7 @@ LIB_TREE_NODE_UNIT::LIB_TREE_NODE_UNIT( LIB_TREE_NODE* aParent, LIB_TREE_ITEM* a
     LibId = aParent->LibId;
 
     Name = namePrefix + " " + aItem->GetUnitReference( aUnit );
-    Desc = wxEmptyString;
+    Desc = aItem->GetUnitDescription( aUnit );
     MatchName = wxEmptyString;
 
     IntrinsicRank = -aUnit;

--- a/eeschema/class_libentry.cpp
+++ b/eeschema/class_libentry.cpp
@@ -146,6 +146,11 @@ wxString LIB_ALIAS::GetUnitReference( int aUnit )
     return LIB_PART::SubReference( aUnit, false );
 }
 
+wxString LIB_ALIAS::GetUnitDescription( int aUnit )
+{
+    return shared->GetUnitDescription(aUnit);
+}
+
 
 const EDA_RECT LIB_ALIAS::GetBoundingBox() const
 {
@@ -341,6 +346,18 @@ wxString LIB_PART::SubReference( int aUnit, bool aAddSeparator )
     return subRef;
 }
 
+wxString LIB_PART::GetUnitDescription( int aUnit )
+{
+    wxString fieldid="_UNITDESC_";
+    fieldid<<LIB_PART::SubReference(aUnit,false);
+    LIB_FIELD* descfield=FindField(fieldid);
+    if(descfield==NULL)
+    {
+        return wxEmptyString;
+    } else {
+        return descfield->GetFullText();
+    }
+}
 
 const wxString& LIB_PART::GetName() const
 {

--- a/eeschema/class_libentry.h
+++ b/eeschema/class_libentry.h
@@ -175,6 +175,11 @@ public:
     wxString GetUnitReference( int aUnit ) override;
 
     /**
+     * For symbols with units, return a unit description for unit x if available.
+     */
+    wxString GetUnitDescription( int aUnit ) override;
+
+    /**
      * A temporary conversion (deMorgan) designation for rendering, preview, etc.
      */
     void SetTmpConversion( int aConversion ) { tmpConversion = aConversion; }
@@ -667,6 +672,12 @@ public:
      * Note: this is a static function.
      */
     static wxString SubReference( int aUnit, bool aAddSeparator = true );
+
+     /**
+     * @return the description of this unit (if any)
+     * @param aUnit = the part identifier ( 1 to max count)
+     */
+    wxString GetUnitDescription( int aUnit);
 
     // Accessors to sub ref parameters
     static int GetSubpartIdSeparator() { return m_subpartIdSeparator; }

--- a/eeschema/libedit/lib_edit_frame.cpp
+++ b/eeschema/libedit/lib_edit_frame.cpp
@@ -372,7 +372,7 @@ void LIB_EDIT_FRAME::UpdatePartSelectList()
         for( int i = 0; i < part->GetUnitCount(); i++ )
         {
             wxString sub  = LIB_PART::SubReference( i+1, false );
-            wxString unit = wxString::Format( _( "Unit %s" ), GetChars( sub ) );
+            wxString unit = wxString::Format( _( "Unit %s %s" ), GetChars( sub ), GetChars(part->GetUnitDescription(i+1)) );
             m_partSelectBox->Append( unit );
         }
     }

--- a/include/lib_tree_item.h
+++ b/include/lib_tree_item.h
@@ -62,6 +62,7 @@ public:
      * For items with units, return an identifier for unit x.
      */
     virtual wxString GetUnitReference( int aUnit ) { return wxEmptyString; }
+    virtual wxString GetUnitDescription( int aUnit ) { return wxEmptyString; }
 };
 
 #endif //LIB_TREE_ITEM_H


### PR DESCRIPTION
If a part has _UNITDESC_A, _UNITDESC_B etc fields their values will be shown as the unit description in the part selection dialog and the unit selection dropdown